### PR TITLE
adding hyperlinks and further detailing to readme files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@
 
 ## Description
 
-There are two servers in FastFriends: backend and frontend.  Refer to each subdirectory's readme to install and run those servers.
+There are two servers in FastFriends: [backend](https://github.com/rvernick/fast-friends/blob/main/backend/README.md) and [frontend](https://github.com/rvernick/fast-friends/blob/main/frontend/README.md).  Refer to each subdirectory's readme to install and run those servers.
 
 ## Stay in touch
 
 - Author - [Russ Vernick](mailto:rvernick@yahoo.com)
-- ToDo - [FastFriends Pivot](https://www.pivotaltracker.com/n/projects/2639100)
+- ToDo - [Trello FastFriends](https://trello.com/b/kyMVNEo0/fast-friends)
 - iOS App - Coming soon

--- a/backend/README.md
+++ b/backend/README.md
@@ -7,6 +7,15 @@ This is the backend server for FastFriends.  It uses the following framworks:
 
 ## Installation
 
+Clone the repository (if not already cloned)
+```bash
+$ git clone https://github.com/rvernick/fast-friends.git
+```
+Move to backend repository on local device
+```bash
+$ cd fast-friends/backend/
+```
+Install Backend package.json
 ```bash
 $ npm install
 ```

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -4,6 +4,15 @@
 
 ## Installation
 
+Clone the repository (if not already cloned)
+```bash
+$ git clone https://github.com/rvernick/fast-friends.git
+```
+Move to frontent repository on local device
+```bash
+$ cd fast-friends/frontend/
+```
+Install Frontend package.json
 ```bash
 $ npm install
 ```


### PR DESCRIPTION
Provided a more detailed breakdown of how to download the package.json files and added hyperlinks from main readme to backend and frontend. Will add further detailing in later commit to ensure nvm and homebrew have sufficient explanation as they are necessary for the installation process.